### PR TITLE
0.2

### DIFF
--- a/unitc
+++ b/unitc
@@ -93,9 +93,9 @@ fi
 
 # Read the significant unitd conifuration from cache file (or create it)
 #
-if [ -r /tmp/${0##*/}.$PID.env ]; then
-	source /tmp/${0##*/}.$PID.env
-else
+#if [ -r /tmp/${0##*/}.$PID.env ]; then
+#	source /tmp/${0##*/}.$PID.env
+#else
 	# Check we have all the tools we need in $PATH
 	#
 	MISSING=$(hash unitd curl ps grep cut tr sed tail sleep 2>&1 | cut -f4 -d: | tr -d '\n')
@@ -153,7 +153,7 @@ else
 	rm /tmp/${0##*/}.* 2> /dev/null
 	echo CURL_ADDR=\"${CURL_ADDR}\" > /tmp/${0##*/}.$PID.env
 	echo ERROR_LOG=${ERROR_LOG} >> /tmp/${0##*/}.$PID.env
-fi
+#fi
 
 # Test for jq
 #

--- a/unitc
+++ b/unitc
@@ -10,7 +10,9 @@ SHOW_LOG=1
 URI=""
 
 usage() {
-  echo "usage"
+	echo "-h: This message"
+	echo "-m: <method> GET / PUT / POST / DELETE / INSERT"
+	echo "-u: <uri> URI or unit config path"
 }
 
 check_unit_running() {
@@ -26,7 +28,7 @@ check_unit_running() {
   fi
 }
 
-while getopts ":h:q:m:uri" o; do
+while getopts "m:u:h" o; do
     case "${o}" in
         h)
             usage
@@ -34,12 +36,17 @@ while getopts ":h:q:m:uri" o; do
         m)
             METHOD=$(echo ${OPTARG} | tr '[a-z]' '[A-Z]')
             ;;
+	u)
+	    URI=${OPTARG}
+	    ;;
         *)
             usage
             ;;
     esac
 done
 shift $((OPTIND-1))
+
+check_unit_running
 
 #if [ -z "${s}" ] || [ -z "${p}" ]; then
 #    usage

--- a/unitc
+++ b/unitc
@@ -75,7 +75,6 @@ while getopts "i:m:p:u:h" o; do
             ;;
     esac
 done
-set -x
 [ $# = 0 ] && usage
 [ -z "$METHOD" ] && METHOD="GET"
 [ -z "$URI" ] && usage uri

--- a/unitc
+++ b/unitc
@@ -5,59 +5,28 @@
 # Defaults
 #
 QUIET=0
-METHOD=PUT
+#METHOD=PUT
+BOLD=$(tput smso)
+NORM=$(tput rmso)
 SHOW_LOG=1
-URI=""
+#URI=""
 
 usage() {
+        if [ $# -gt 0 ]
+        then
+          local varname=$1
+          echo "${BOLD} $varname is missing please set $varname and try again."
+          echo ${NORM}
+        fi
+
+	echo "${0##*/} - a curl wrapper for configuring NGINX Unit"
+	echo ""
 	echo "-h: This message"
 	echo "-m: <method> GET / PUT / POST / DELETE / INSERT"
 	echo "-u: <uri> URI or unit config path"
-}
-
-check_unit_running() {
-  # Check if Unit is running, find the main process
-  #
-  PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
-  if [ ${#PID[@]} -eq 0 ]; then
-  	echo "${0##*/}: ERROR: unitd not running"
-  	exit 1
-  elif [ ${#PID[@]} -gt 1 ]; then
-  	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
-  	exit 1
-  fi
-}
-
-while getopts "m:u:h" o; do
-    case "${o}" in
-        h)
-            usage
-            ;;
-        m)
-            METHOD=$(echo ${OPTARG} | tr '[a-z]' '[A-Z]')
-            ;;
-	u)
-	    URI=${OPTARG}
-	    ;;
-        *)
-            usage
-            ;;
-    esac
-done
-shift $((OPTIND-1))
-
-check_unit_running
-
-#if [ -z "${s}" ] || [ -z "${p}" ]; then
-#    usage
-#fi
-
-
-if [ "$URI" = "" ]; then
-	echo "${0##*/} - a curl wrapper for configuring NGINX Unit"
-	echo ""
-	echo "USAGE: ${0##*/} [--quiet] [HTTP method] URI"
-	echo ""
+        echo "-i: <IP> IP address of remote host"
+        echo "-p: <port> port on remote host (80 is default)"
+        echo ""
 	echo " URI is for the Unit configuration API, e.g. /config"
 	echo " --quiet (-q) Will not monitor the error log after config changes"
 	echo ""
@@ -68,7 +37,77 @@ if [ "$URI" = "" ]; then
 	echo " • The control socket is automatically detected"
 	echo ""
 	exit 1
-fi
+}
+
+check_unit_running() {
+  # Check if Unit is running, find the main process
+  #
+  PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
+  if [ ${#PID[@]} -eq 0 ]; then
+  	echo "${0##*/}: INFO: unitd not running locally.... assuming remote"
+        IS_REMOTE=true
+  	#echo "${0##*/}: ERROR: unitd not running"
+  	#exit 1
+  elif [ ${#PID[@]} -gt 1 ]; then
+  	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
+  	exit 1
+  else 
+        IS_REMOTE=false
+  fi
+}
+
+while getopts "i:m:p:u:h" o; do
+    case "${o}" in
+        h)
+            usage
+            ;;
+        m)
+            METHOD=$(echo ${OPTARG} | tr '[a-z]' '[A-Z]')
+            ;;
+	u)
+	    URI=${OPTARG}
+	    ;;
+        i)  REMOTE_IP=${OPTARG}
+            ;;
+        p)  REMOTE_PORT=${OPTARG}
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+[ $# = 0 ] && usage
+[ -z "$METHOD" ] && usage method
+[ -z "$URI" ] && usage uri
+
+shift $((OPTIND-1))
+
+check_unit_running
+[[ -z "${REMOTE_IP}" ]] && echo "foo"
+[[ -z "${REMOTE_PORT}" ]] && echo "foo"
+echo $REMOTE_HOST
+echo $REMOTE_IP
+echo $REMOTE_PORT
+
+#if [ -z "${s}" ] || [ -z "${p}" ]; then
+#    usage
+#fi
+
+
+#if [ "$URI" = "" ]; then
+#	echo "USAGE: ${0##*/} [--quiet] [HTTP method] URI"
+#	echo ""
+#	echo " URI is for the Unit configuration API, e.g. /config"
+#	echo " --quiet (-q) Will not monitor the error log after config changes"
+#	echo ""
+#	echo " • Configuration JSON is read from stdin"
+#	echo " • Default HTTP method is PUT for config changes, else GET"
+#	echo " • Virtual method INSERT adds to beginning of array"
+#	echo " • Options can appear in any position, e.g. method after URI"
+#	echo " • The control socket is automatically detected"
+#	echo ""
+#	exit 1
+#fi
 
 
 # Read the significant unitd conifuration from cache file (or create it)
@@ -84,28 +123,34 @@ else
 		exit 1
 	fi
 
-	PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
+#### Only do this is REMOTE not true
+        if [ "$IS_REMOTE" = "false" ] ; then
+	        PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 
-	# Get control address
-	#
-	CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
-	if [ "$CTRL_ADDR" = "" ]; then
-		CTRL_ADDR=$(unitd --help | grep -A1 '\--control' | tail -1 |  cut -f2 -d\")
-	fi
+	        # Get control address
+	        #
+	        CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
+	        if [ "$CTRL_ADDR" = "" ]; then
+	        	CTRL_ADDR=$(unitd --help | grep -A1 '\--control' | tail -1 |  cut -f2 -d\")
+	        fi
 
-	# Prepare for network or Unix socket addressing
-	#
-	if [ $(echo $CTRL_ADDR | grep -c ^unix:) -eq 1 ]; then
-		SOCK_FILE=$(echo $CTRL_ADDR | cut -f2- -d:)
-		if [ -r $SOCK_FILE ]; then
-			CURL_ADDR="--unix-socket $SOCK_FILE _"
-		else
-			echo "${0##*/}: ERROR: cannot read unitd control socket: $SOCK_FILE"
-			ls -l $SOCK_FILE
-			exit 2
-		fi
+	        # Prepare for network or Unix socket addressing
+	        #
+	        if [ $(echo $CTRL_ADDR | grep -c ^unix:) -eq 1 ]; then
+	        	SOCK_FILE=$(echo $CTRL_ADDR | cut -f2- -d:)
+	        	if [ -r $SOCK_FILE ]; then
+	        		CURL_ADDR="--unix-socket $SOCK_FILE _"
+	        	else
+	        		echo "${0##*/}: ERROR: cannot read unitd control socket: $SOCK_FILE"
+	        		ls -l $SOCK_FILE
+	        		exit 2
+	        	fi
+                fi
+        #fi ## end of IS_REMOTE check
+#### This is where we pass in ip and port
 	else
-		CURL_ADDR="http://$CTRL_ADDR"
+	     	#CURL_ADDR="http://$CTRL_ADDR"
+                CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
 	fi
 
 	# Get error log filename

--- a/unitc
+++ b/unitc
@@ -105,7 +105,7 @@ else
 	fi
 
         # Only do this is REMOTE not true means that unitc is not running locally
-        if [ "$IS_REMOTE" -eq 1 ] ; then
+        if [ "$IS_REMOTE" -eq 0 ] ; then
 	        PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 
 	        # Get control address

--- a/unitc
+++ b/unitc
@@ -134,6 +134,11 @@ fi
                   echo "${0##*/}: INFO: running locally, unit is bound to ip and port combination"
                   LOCAL_IP=$(echo ${CTRL_ADDR} | cut -d ':' -f1)
                   LOCAL_PORT=$(echo ${CTRL_ADDR} | cut -d ':' -f2)
+                  if [ $LOCAL_IP = "0.0.0.0" ]
+                  then 
+                      LOCAL_IP="127.0.0.1"
+                  fi
+                  CURL_ADDR="http://${LOCAL_IP}:${LOCAL_PORT}"
                 fi
                
         # This is where we pass in ip and port

--- a/unitc
+++ b/unitc
@@ -104,7 +104,7 @@ else
 		exit 1
 	fi
 
-        # Only do this is REMOTE not true means that unitc is not running locally
+        # Only do this if IS_REMOTE is not true, this means that unitc is running locally on the unit server
         if [ "$IS_REMOTE" -eq 0 ] ; then
 	        PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 

--- a/unitc
+++ b/unitc
@@ -9,39 +9,42 @@ METHOD=PUT
 SHOW_LOG=1
 URI=""
 
-while [ $# -gt 0 ]; do
-	OPTION=$(echo $1 | tr '[a-z]' '[A-Z]')
-	case $OPTION in
-		"-H" | "--HELP")
-			shift
-			;;
+usage() {
+  echo "usage"
+}
 
-		"-Q" | "--QUIET")
-			QUIET=1
-			shift
-			;;
+check_unit_running() {
+  # Check if Unit is running, find the main process
+  #
+  PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
+  if [ ${#PID[@]} -eq 0 ]; then
+  	echo "${0##*/}: ERROR: unitd not running"
+  	exit 1
+  elif [ ${#PID[@]} -gt 1 ]; then
+  	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
+  	exit 1
+  fi
+}
 
-		"GET" | "PUT" | "POST" | "DELETE" | "INSERT")
-			METHOD=$OPTION
-			shift
-			;;
-
-		"HEAD" | "PATCH" | "PURGE" | "OPTIONS")
-			echo "${0##*/}: ERROR: Invalid HTTP method ($OPTION)"
-			exit 1
-			;;
-
-		*)
-			if [ "${1:0:1}" = "/" ]; then
-				URI=$1
-				shift
-			else
-				echo "${0##*/}: ERROR: Invalid option ($1)"
-				exit 1
-			fi
-			;;
-	esac
+while getopts ":h:q:m:uri" o; do
+    case "${o}" in
+        h)
+            usage
+            ;;
+        m)
+            METHOD=$(echo ${OPTARG} | tr '[a-z]' '[A-Z]')
+            ;;
+        *)
+            usage
+            ;;
+    esac
 done
+shift $((OPTIND-1))
+
+#if [ -z "${s}" ] || [ -z "${p}" ]; then
+#    usage
+#fi
+
 
 if [ "$URI" = "" ]; then
 	echo "${0##*/} - a curl wrapper for configuring NGINX Unit"
@@ -60,16 +63,6 @@ if [ "$URI" = "" ]; then
 	exit 1
 fi
 
-# Check if Unit is running, find the main process
-#
-PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
-if [ ${#PID[@]} -eq 0 ]; then
-	echo "${0##*/}: ERROR: unitd not running"
-	exit 1
-elif [ ${#PID[@]} -gt 1 ]; then
-	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
-	exit 1
-fi
 
 # Read the significant unitd conifuration from cache file (or create it)
 #

--- a/unitc
+++ b/unitc
@@ -161,6 +161,8 @@ else
 	QUIET=1
 fi
 
+set -x
+
 # Adjust HTTP method and curl params based on presence of stdin payload
 #
 if [ -t 0 ]; then
@@ -207,5 +209,3 @@ if [ $SHOW_LOG -gt 0 ] && [ $QUIET -eq 0 ]; then
 	echo ""
 	sed -n $((LOG_LEN+1)),\$p $ERROR_LOG
 fi
-
-# vim: syntax=bash

--- a/unitc
+++ b/unitc
@@ -132,9 +132,8 @@ else
                 if [ $LOCAL_IP_AND_PORT -eq 1 ] 
                 then
                   echo "${0##*/}: INFO: running locally, unit is bound to ip and port combination"
-                  LOCAL_IP=$(echo $LOCAL_IP_AND_PORT | cut -d ':' -f1)
-                  LOCAL_PORT=$(echo $LOCAL_IP_AND_PORT | cut -d ':' -f2)
-            
+                  LOCAL_IP=$(echo ${CTRL_ADDR} | cut -d ':' -f1)
+                  LOCAL_PORT=$(echo ${CTRL_ADDR} | cut -d ':' -f2)
                 fi
                
         # This is where we pass in ip and port

--- a/unitc
+++ b/unitc
@@ -5,11 +5,10 @@
 # Defaults
 #
 QUIET=0
-#METHOD=PUT
 BOLD=$(tput smso)
 NORM=$(tput rmso)
 SHOW_LOG=1
-#URI=""
+IS_REMOTE=0
 
 usage() {
         if [ $# -gt 0 ]
@@ -45,14 +44,14 @@ check_unit_running() {
   PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
   if [ ${#PID[@]} -eq 0 ]; then
   	echo "${0##*/}: INFO: unitd not running locally.... assuming remote"
-        IS_REMOTE=true
+        IS_REMOTE=1
   	#echo "${0##*/}: ERROR: unitd not running"
   	#exit 1
   elif [ ${#PID[@]} -gt 1 ]; then
   	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
   	exit 1
   else 
-        IS_REMOTE=false
+        IS_REMOTE=0
   fi
 }
 
@@ -77,38 +76,19 @@ while getopts "i:m:p:u:h" o; do
     esac
 done
 [ $# = 0 ] && usage
-[ -z "$METHOD" ] && usage method
+[ -z "$METHOD" ] && METHOD="GET"
 [ -z "$URI" ] && usage uri
 
-shift $((OPTIND-1))
+#shift $((OPTIND-1))
 
 check_unit_running
-[[ -z "${REMOTE_IP}" ]] && echo "foo"
-[[ -z "${REMOTE_PORT}" ]] && echo "foo"
-echo $REMOTE_HOST
-echo $REMOTE_IP
-echo $REMOTE_PORT
-
-#if [ -z "${s}" ] || [ -z "${p}" ]; then
-#    usage
-#fi
-
-
-#if [ "$URI" = "" ]; then
-#	echo "USAGE: ${0##*/} [--quiet] [HTTP method] URI"
-#	echo ""
-#	echo " URI is for the Unit configuration API, e.g. /config"
-#	echo " --quiet (-q) Will not monitor the error log after config changes"
-#	echo ""
-#	echo " • Configuration JSON is read from stdin"
-#	echo " • Default HTTP method is PUT for config changes, else GET"
-#	echo " • Virtual method INSERT adds to beginning of array"
-#	echo " • Options can appear in any position, e.g. method after URI"
-#	echo " • The control socket is automatically detected"
-#	echo ""
-#	exit 1
-#fi
-
+if [ $IS_REMOTE -eq 1 ]
+then
+  # If we are using a remote connection then we will need to have both the IP and the port.
+  # There is no checking of proper quad notation for IP address
+  [ -z "$REMOTE_IP" ] && usage "remote IP address"
+  [ -z "$REMOTE_PORT" ] && usage "port"
+fi
 
 # Read the significant unitd conifuration from cache file (or create it)
 #
@@ -124,7 +104,7 @@ else
 	fi
 
 #### Only do this is REMOTE not true
-        if [ "$IS_REMOTE" = "false" ] ; then
+        if [ "$IS_REMOTE" -eq 1 ] ; then
 	        PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 
 	        # Get control address
@@ -146,10 +126,8 @@ else
 	        		exit 2
 	        	fi
                 fi
-        #fi ## end of IS_REMOTE check
-#### This is where we pass in ip and port
+        # This is where we pass in ip and port
 	else
-	     	#CURL_ADDR="http://$CTRL_ADDR"
                 CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
 	fi
 

--- a/unitc
+++ b/unitc
@@ -75,6 +75,7 @@ while getopts "i:m:p:u:h" o; do
             ;;
     esac
 done
+set -x
 [ $# = 0 ] && usage
 [ -z "$METHOD" ] && METHOD="GET"
 [ -z "$URI" ] && usage uri
@@ -103,7 +104,7 @@ else
 		exit 1
 	fi
 
-#### Only do this is REMOTE not true
+        # Only do this is REMOTE not true means that unitc is not running locally
         if [ "$IS_REMOTE" -eq 1 ] ; then
 	        PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 
@@ -160,8 +161,6 @@ if [ -f $ERROR_LOG ] && [ -r $ERROR_LOG ]; then
 else
 	QUIET=1
 fi
-
-set -x
 
 # Adjust HTTP method and curl params based on presence of stdin payload
 #

--- a/unitc
+++ b/unitc
@@ -127,7 +127,7 @@ fi
 	        	fi
                 fi
                 # If we run locally on the unit server, but the control address is 0.0.0.0 curl will fail
-                LOCAL_IP_AND_PORT=$(echo $CTRL_ADDR | grep -c ':')
+                LOCAL_IP_AND_PORT=$(echo $CTRL_ADDR | grep -v unix | grep -c ':')
                 if [ $LOCAL_IP_AND_PORT -eq 1 ] 
                 then
                   echo "${0##*/}: INFO: running locally, unit is bound to ip and port combination"

--- a/unitc
+++ b/unitc
@@ -127,10 +127,19 @@ else
 	        		exit 2
 	        	fi
                 fi
+                # If we run locally on the unit server, but the control address is 0.0.0.0 curl will fail
+                LOCAL_IP_AND_PORT=$(echo $CTRL_ADDR | grep -c ':')
+                if [ $LOCAL_IP_AND_PORT -eq 1 ] 
+                then
+                  echo "${0##*/}: INFO: running locally, unit is bound to ip and port combination"
+                  LOCAL_IP=$(echo $LOCAL_IP_AND_PORT | cut -d ':' -f1)
+                  LOCAL_PORT=$(echo $LOCAL_IP_AND_PORT | cut -d ':' -f2)
+            
+                fi
+               
         # This is where we pass in ip and port
 	else
-                CURL_ADDR="http://$CTRL_ADDR"
-                #CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
+                CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
 	fi
 
 	# Get error log filename

--- a/unitc
+++ b/unitc
@@ -129,7 +129,8 @@ else
                 fi
         # This is where we pass in ip and port
 	else
-                CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
+                CURL_ADDR="http://$CTRL_ADDR"
+                #CURL_ADDR="http://${REMOTE_IP}:${REMOTE_PORT}"
 	fi
 
 	# Get error log filename


### PR DESCRIPTION
New pull request creates the ability to run unitc either locally or from a remote machine.

This will allow a user to run unitc either locally on a unit server and use the control socket configure unit, or from a machine that does not run unit and configure an ip / port combination to make unitc talk to the configured tcp / http control channel.

-----------
unitc - a curl wrapper for configuring NGINX Unit

-h: This message
-m: <method> GET / PUT / POST / DELETE / INSERT
-u: <uri> URI or unit config path
-i: <IP> IP address of remote host
-p: <port> port on remote host (80 is default)

 URI is for the Unit configuration API, e.g. /config
 --quiet (-q) Will not monitor the error log after config changes

 • Configuration JSON is read from stdin
 • Default HTTP method is PUT for config changes, else GET
 • Virtual method INSERT adds to beginning of array
 • Options can appear in any position, e.g. method after URI
 • The control socket is automatically detected
-------------



examples #1 - running locally using local control socket
----------
 ps -ef | grep unit
root       68778       1  0 08:10 ?        00:00:00 unit: main v1.26.1 [/usr/sbin/unitd]
unit       68781   68778  0 08:10 ?        00:00:00 unit: controller
unit       68782   68778  0 08:10 ?        00:00:00 unit: router
root       69340    7983  0 08:19 pts/0    00:00:00 grep --color=auto unit


./unitc -u /config
{
        "listeners": {},
        "applications": {}
}




example #2 - running locally using ip and port binding
--------------
ps -ef | grep unit
root       69458       1  0 08:20 ?        00:00:00 unit: main v1.26.1 [unitd --control 10.1.1.128:80]
unit       69460   69458  0 08:20 ?        00:00:00 unit: controller
unit       69461   69458  0 08:20 ?        00:00:00 unit: router
root       69476    7983  0 08:20 pts/0    00:00:00 grep --color=auto unit


./unitc -u /config
unitc: INFO: running locally, unit is bound to ip and port combination
{
        "listeners": {},
        "applications": {}
}



example #3 - running locally using 0.0.0.0 (special case as curl cannot send a request to 0.0.0.0 but unit is capable of listening on all interfaces)
-----------
 ps -ef | grep unit
root       69563       1  0 08:22 ?        00:00:00 unit: main v1.26.1 [unitd --control 0.0.0.0:80]
unit       69565   69563  0 08:22 ?        00:00:00 unit: controller
unit       69566   69563  0 08:22 ?        00:00:00 unit: router
root       69595    7983  0 08:23 pts/0    00:00:00 grep --color=auto unit


./unitc -u /config
unitc: INFO: running locally, unit is bound to ip and port combination
{
        "listeners": {},
        "applications": {}
}



example #4 - running on a machine that is "remote" where unit does not run, not supplying port or ip of remote server
--------------
 ps -ef | grep unit
root        4185    2280  0 19:24 pts/0    00:00:00 grep --color=auto unit


./unitc -u /config
unitc: INFO: unitd not running locally.... assuming remote
 remote IP address is missing please set remote IP address and try again.

unitc - a curl wrapper for configuring NGINX Unit

-h: This message
-m: <method> GET / PUT / POST / DELETE / INSERT
-u: <uri> URI or unit config path
-i: <IP> IP address of remote host
-p: <port> port on remote host (80 is default)

 URI is for the Unit configuration API, e.g. /config
 --quiet (-q) Will not monitor the error log after config changes

 • Configuration JSON is read from stdin
 • Default HTTP method is PUT for config changes, else GET
 • Virtual method INSERT adds to beginning of array
 • Options can appear in any position, e.g. method after URI
 • The control socket is automatically detected



example #5 - running on a machine that is "remote" where unit does not run, not supplying port remote server
--------------
./unitc -u /config -i 10.1.1.128
unitc: INFO: unitd not running locally.... assuming remote
 port is missing please set port and try again.

unitc - a curl wrapper for configuring NGINX Unit

-h: This message
-m: <method> GET / PUT / POST / DELETE / INSERT
-u: <uri> URI or unit config path
-i: <IP> IP address of remote host
-p: <port> port on remote host (80 is default)

 URI is for the Unit configuration API, e.g. /config
 --quiet (-q) Will not monitor the error log after config changes

 • Configuration JSON is read from stdin
 • Default HTTP method is PUT for config changes, else GET
 • Virtual method INSERT adds to beginning of array
 • Options can appear in any position, e.g. method after URI
 • The control socket is automatically detected




example #6 - running on a machine that is "remote" where unit does not run but supplying both ip and port of remote unit server
--------------
./unitc -u /config -i 10.1.1.128 -p 80
unitc: INFO: unitd not running locally.... assuming remote
{
  "listeners": {},
  "applications": {}
}




TODO:
------
- update README
- cater for unit not running on remote (curl currently just throws a nasty error)
- cater for https
- cater for some edge cases