### PR TITLE
Add remote mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ unitc
 
 ## A curl wrapper for configuring NGINX Unit
 
-```USAGE: unitc [--quiet] [HTTP method] URI```
+```USAGE: unitc [--quiet] [ssh://remote:/socket] [HTTP method] URI```
 
 Providing a JSON configuration on stdin will use the PUT method unless a specific
 method is provided. Otherwise a GET is used to read the configuration. A virtual
@@ -41,7 +41,7 @@ unitc delete /config/applications/wp
 ### Remote configuration
 
 The configuration of a remote Unit instance can be controlled by specifying the
-URI as a complete URL (with protocol).
+control socket as ssh://… or with a URI complete with protocol (http://…).
 
 Alternatively, the remote control socket can be set with the
 `$UNIT_CTRL` environment variable.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 unitc
 =====
 
-A curl wrapper for configuring NGINX Unit
------------------------------------------
+## A curl wrapper for configuring NGINX Unit
 
-Just provide the configuration URI (e.g. `/config/routes`) and **unitc** will
-find the control socket to construct the full address in curl syntax.
-
-```USAGE: unitc [HTTP method] [--quiet] URI```
+```USAGE: unitc [--quiet] [HTTP method] URI```
 
 Providing a JSON configuration on stdin will use the PUT method unless a specific
 method is provided. Otherwise a GET is used to read the configuration. A virtual
@@ -16,6 +12,19 @@ HTTP methods can be specified in lower case.
 
 [jq](https://stedolan.github.io/jq/) is used to prettify the output, if available.
 Required if using the INSERT method.
+
+Command line options can be specified in any order. For example, a redundant part
+of the configuration can be located by URI and appended with `delete` in a subsequent
+invocation.
+```shell
+unitc /config/routes/0
+unitc /config/routes/0 delete
+```
+
+### Local configuration
+
+Just provide the configuration URI (e.g. `/config/routes`) and **unitc** will
+find the control socket to construct the full address in curl syntax.
 
 When making changes, the error log is monitored and new log entries are shown.
 
@@ -29,10 +38,19 @@ unitc /config < unitconf.json
 unitc delete /config/applications/wp
 ```
 
-Command line options can be specified in any order. For example, a redundant part
-of the configuration can be located by URI and appended with `delete` in a subsequent
-invocation.
+### Remote configuration
+
+The configuration of a remote Unit instance can be controlled by specifying the
+URI as a complete URL (with protocol).
+
+Alternatively, the remote control socket can be set with the
+`$UNIT_CTRL` environment variable.
+
+Examples:
 ```shell
-unitc /config/routes/0
-unitc /config/routes/0 delete
+unitc http://192.168.0.1:8080/config
+UNIT_CTRL=http:////192.168.0.1:8080 unitc /config
+
+export UNIT_CTRL=http://192.168.0.1:8080
+echo '{"match": {"uri":"/foo"}, "action": {"pass":"applications/foo"}}'| unitc /config/routes insert
 ```

--- a/unitc
+++ b/unitc
@@ -4,6 +4,8 @@
 
 # Defaults
 #
+ERROR_LOG=/dev/null
+REMOTE=0
 QUIET=0
 METHOD=PUT
 SHOW_LOG=1
@@ -32,7 +34,7 @@ while [ $# -gt 0 ]; do
 			;;
 
 		*)
-			if [ "${1:0:1}" = "/" ]; then
+			if [ "${1:0:1}" = "/" ] || [ "${1:0:4}" = "http" ]; then
 				URI=$1
 				shift
 			else
@@ -49,77 +51,93 @@ if [ "$URI" = "" ]; then
 	echo "USAGE: ${0##*/} [--quiet] [HTTP method] URI"
 	echo ""
 	echo " URI is for the Unit configuration API, e.g. /config"
+	echo " URI with protocol (e.g. http://...) can be used for remote configuration"
 	echo " --quiet (-q) Will not monitor the error log after config changes"
 	echo ""
+	echo " • Environment variable \$UNIT_CTRL may specify remote host"
 	echo " • Configuration JSON is read from stdin"
 	echo " • Default HTTP method is PUT for config changes, else GET"
 	echo " • Virtual method INSERT adds to beginning of array"
 	echo " • Options can appear in any position, e.g. method after URI"
-	echo " • The control socket is automatically detected"
+	echo " • The control socket is automatically detected for local installations"
 	echo ""
 	exit 1
 fi
 
-# Check if Unit is running, find the main process
+# Figure out if we're running on the Unit host, or remotely
 #
-PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
-if [ ${#PID[@]} -eq 0 ]; then
-	echo "${0##*/}: ERROR: unitd not running"
-	exit 1
-elif [ ${#PID[@]} -gt 1 ]; then
-	echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
-	exit 1
+if [ "$UNIT_CTRL" = "" ]; then
+	if [ "${URI:0:4}" = "http" ]; then
+		REMOTE=1
+		UNIT_CTRL=$(echo "$URI" | cut -f1-3 -d/)
+		URI=/$(echo "$URI" | cut -f4- -d/)
+	fi
+elif [ "${URI:0:1}" = "/" ]; then
+	REMOTE=1
 fi
 
-# Read the significant unitd conifuration from cache file (or create it)
-#
-if [ -r /tmp/${0##*/}.$PID.env ]; then
-	source /tmp/${0##*/}.$PID.env
-else
-	# Check we have all the tools we need in $PATH
+if [ $REMOTE -eq 0 ]; then
+	# Check if Unit is running, find the main process
 	#
-	MISSING=$(hash unitd curl ps grep cut tr sed tail sleep 2>&1 | cut -f4 -d: | tr -d '\n')
-	if [ "$MISSING" != "" ]; then
-		echo "${0##*/}: ERROR: cannot find$MISSING: please install or add to \$PATH"
+	PID=($(ps ax | grep unit:\ main | grep -v \ grep | awk '{print $1}'))
+	if [ ${#PID[@]} -eq 0 ]; then
+		echo "${0##*/}: ERROR: unitd not running"
+		exit 1
+	elif [ ${#PID[@]} -gt 1 ]; then
+		echo "${0##*/}: ERROR: multiple unitd processes detected (${PID[@]})"
 		exit 1
 	fi
 
-	PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
-
-	# Get control address
+	# Read the significant unitd conifuration from cache file (or create it)
 	#
-	CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
-	if [ "$CTRL_ADDR" = "" ]; then
-		CTRL_ADDR=$(unitd --help | grep -A1 '\--control' | tail -1 |  cut -f2 -d\")
-	fi
-
-	# Prepare for network or Unix socket addressing
-	#
-	if [ $(echo $CTRL_ADDR | grep -c ^unix:) -eq 1 ]; then
-		SOCK_FILE=$(echo $CTRL_ADDR | cut -f2- -d:)
-		if [ -r $SOCK_FILE ]; then
-			CURL_ADDR="--unix-socket $SOCK_FILE _"
-		else
-			echo "${0##*/}: ERROR: cannot read unitd control socket: $SOCK_FILE"
-			ls -l $SOCK_FILE
-			exit 2
-		fi
+	if [ -r /tmp/${0##*/}.$PID.env ]; then
+		source /tmp/${0##*/}.$PID.env
 	else
-		CURL_ADDR="http://$CTRL_ADDR"
-	fi
+		# Check we have all the tools we need in $PATH
+		#
+		MISSING=$(hash curl ps grep tr sed tail sleep 2>&1 | cut -f4 -d: | tr -d '\n')
+		if [ "$MISSING" != "" ]; then
+			echo "${0##*/}: ERROR: cannot find$MISSING: please install or add to \$PATH"
+			exit 1
+		fi
 
-	# Get error log filename
-	#
-	ERROR_LOG=$(echo "$PARAMS" | grep '\--log' | cut -f2 -d' ')
-	if [ "$ERROR_LOG" = "" ]; then
-		ERROR_LOG=$(unitd --help | grep -A1 '\--log' | tail -1 | cut -f2 -d\")
-	fi
+		PARAMS=$(ps $PID | grep unitd | cut -f2- -dv | tr '[]' ' ' | cut -f4- -d ' ' | sed -e 's/ --/\n--/g')
 
-	# Cache the discovery for this unit PID (and cleanup any old files)
-	#
-	rm /tmp/${0##*/}.* 2> /dev/null
-	echo CURL_ADDR=\"${CURL_ADDR}\" > /tmp/${0##*/}.$PID.env
-	echo ERROR_LOG=${ERROR_LOG} >> /tmp/${0##*/}.$PID.env
+		# Get control address
+		#
+		CTRL_ADDR=$(echo "$PARAMS" | grep '\--control' | cut -f2 -d' ')
+		if [ "$CTRL_ADDR" = "" ]; then
+			CTRL_ADDR=$(unitd --help | grep -A1 '\--control' | tail -1 |  cut -f2 -d\")
+		fi
+
+		# Prepare for network or Unix socket addressing
+		#
+		if [ $(echo $CTRL_ADDR | grep -c ^unix:) -eq 1 ]; then
+			SOCK_FILE=$(echo $CTRL_ADDR | cut -f2- -d:)
+			if [ -r $SOCK_FILE ]; then
+				UNIT_CTRL="--unix-socket $SOCK_FILE _"
+			else
+				echo "${0##*/}: ERROR: cannot read unitd control socket: $SOCK_FILE"
+				ls -l $SOCK_FILE
+				exit 2
+			fi
+		else
+			UNIT_CTRL="http://$CTRL_ADDR"
+		fi
+
+		# Get error log filename
+		#
+		ERROR_LOG=$(echo "$PARAMS" | grep '\--log' | cut -f2 -d' ')
+		if [ "$ERROR_LOG" = "" ]; then
+			ERROR_LOG=$(unitd --help | grep -A1 '\--log' | tail -1 | cut -f2 -d\")
+		fi
+
+		# Cache the discovery for this unit PID (and cleanup any old files)
+		#
+		rm /tmp/${0##*/}.* 2> /dev/null
+		echo UNIT_CTRL=\"${UNIT_CTRL}\" > /tmp/${0##*/}.$PID.env
+		echo ERROR_LOG=${ERROR_LOG} >> /tmp/${0##*/}.$PID.env
+	fi
 fi
 
 # Test for jq
@@ -142,10 +160,10 @@ fi
 #
 if [ -t 0 ]; then
 	if [ "$METHOD" = "DELETE" ]; then
-		curl -X $METHOD $CURL_ADDR$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		curl -X $METHOD $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	else
 		SHOW_LOG=$(echo $URI | grep -c ^/control/)
-		curl $CURL_ADDR$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		curl $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	fi
 else
 	if [ "$METHOD" = "INSERT" ]; then
@@ -153,16 +171,16 @@ else
 			echo "${0##*/}: ERROR: jq(1) is required to use INSERT method, install at <https://stedolan.github.io/jq/>"
 			exit 1
 		fi
-		CURR_VAL=$(curl -s $CURL_ADDR$URI)
+		CURR_VAL=$(curl -s $UNIT_CTRL$URI)
 		if [ "$(echo $CURR_VAL | jq -r type)" = "array" ]; then
 			SUFFIX=$(cat)
-			echo $CURR_VAL | jq ". |= [$SUFFIX] + ." | curl -X PUT --data-binary @- $CURL_ADDR$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+			echo $CURR_VAL | jq ". |= [$SUFFIX] + ." | curl -X PUT --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 		else
 			echo "${0##*/}: ERROR: INSERT method must be used with an array"
 			exit 3
 		fi
 	else
-		echo "$(cat)" | curl -X $METHOD --data-binary @- $CURL_ADDR$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		echo "$(cat)" | curl -X $METHOD --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	fi
 fi
 
@@ -172,6 +190,7 @@ if [ $CURL_STATUS -ne 0 ]; then
 	if [ $CURL_STATUS -eq 7 ]; then
 		echo "${0##*/}: Check that you have permission to access the Unit control socket, or try again with sudo(8)"
 	else
+		echo "${0##*/}: Trying to access $UNIT_CTRL$URI"
 		cat /tmp/${0##*/}.$$ && rm /tmp/${0##*/}.$$
 	fi
 	exit 4

--- a/unitc
+++ b/unitc
@@ -38,6 +38,11 @@ while [ $# -gt 0 ]; do
 			if [ "${1:0:1}" = "/" ] || [ "${1:0:4}" = "http" ]; then
 				URI=$1
 				shift
+			elif [ "${1:0:6}" = "ssh://" ]; then
+				REMOTE=1
+				SSH_CMD="ssh $(echo $1 | tr '/:' ' ' | cut -f4 -d ' ')"
+				UNIT_CTRL="--unix-socket /$(echo $1 | cut -f4- -d/) _"
+				shift
 			else
 				echo "${0##*/}: ERROR: Invalid option ($1)"
 				exit 1
@@ -49,10 +54,11 @@ done
 if [ "$URI" = "" ]; then
 	echo "${0##*/} - a curl wrapper for configuring NGINX Unit"
 	echo ""
-	echo "USAGE: ${0##*/} [--quiet] [HTTP method] URI"
+	echo "USAGE: ${0##*/} [--quiet] [ssh://remote:/socket] [HTTP method] URI"
 	echo ""
 	echo " URI is for the Unit configuration API, e.g. /config"
-	echo " URI with protocol (e.g. http://...) can be used for remote configuration"
+	echo " URI with protocol (e.g. http://…) can be used for remote configuration"
+	echo " Remote configuration is plaintext and insecure unless using ssh://…"
 	echo ""
 	echo " The control socket is automatically detected for local installations."
 	echo " Remote control socket may be set using \$UNIT_CTRL environment variable as:"
@@ -210,5 +216,3 @@ if [ $SHOW_LOG -gt 0 ] && [ $QUIET -eq 0 ]; then
 	echo ""
 	sed -n $((LOG_LEN+1)),\$p $ERROR_LOG
 fi
-
-# vim: syntax=bash

--- a/unitc
+++ b/unitc
@@ -10,6 +10,7 @@ QUIET=0
 METHOD=PUT
 SHOW_LOG=1
 URI=""
+SSH_CMD=""
 
 while [ $# -gt 0 ]; do
 	OPTION=$(echo $1 | tr '[a-z]' '[A-Z]')
@@ -52,14 +53,16 @@ if [ "$URI" = "" ]; then
 	echo ""
 	echo " URI is for the Unit configuration API, e.g. /config"
 	echo " URI with protocol (e.g. http://...) can be used for remote configuration"
-	echo " --quiet (-q) Will not monitor the error log after config changes"
 	echo ""
-	echo " • Environment variable \$UNIT_CTRL may specify remote host"
+	echo " The control socket is automatically detected for local installations."
+	echo " Remote control socket may be set using \$UNIT_CTRL environment variable as:"
+	echo "  http://remote_host:port  -OR-  ssh://user@remote_host:/path/to/control.sock"
+	echo ""
 	echo " • Configuration JSON is read from stdin"
 	echo " • Default HTTP method is PUT for config changes, else GET"
 	echo " • Virtual method INSERT adds to beginning of array"
 	echo " • Options can appear in any position, e.g. method after URI"
-	echo " • The control socket is automatically detected for local installations"
+	echo " • Error log is monitored for changes when local, unless --quiet (-q)"
 	echo ""
 	exit 1
 fi
@@ -72,6 +75,10 @@ if [ "$UNIT_CTRL" = "" ]; then
 		UNIT_CTRL=$(echo "$URI" | cut -f1-3 -d/)
 		URI=/$(echo "$URI" | cut -f4- -d/)
 	fi
+elif [ "${UNIT_CTRL:0:6}" = "ssh://" ]; then
+	REMOTE=1
+	SSH_CMD="ssh $(echo $UNIT_CTRL | tr '/:' ' ' | cut -f4 -d ' ')"
+	UNIT_CTRL="--unix-socket /$(echo $UNIT_CTRL | cut -f4- -d/) _"
 elif [ "${URI:0:1}" = "/" ]; then
 	REMOTE=1
 fi
@@ -160,10 +167,10 @@ fi
 #
 if [ -t 0 ]; then
 	if [ "$METHOD" = "DELETE" ]; then
-		curl -X $METHOD $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		$SSH_CMD curl -X $METHOD $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	else
 		SHOW_LOG=$(echo $URI | grep -c ^/control/)
-		curl $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		$SSH_CMD curl $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	fi
 else
 	if [ "$METHOD" = "INSERT" ]; then
@@ -171,16 +178,16 @@ else
 			echo "${0##*/}: ERROR: jq(1) is required to use INSERT method, install at <https://stedolan.github.io/jq/>"
 			exit 1
 		fi
-		CURR_VAL=$(curl -s $UNIT_CTRL$URI)
+		SUFFIX=$(cat) # Preserve stdin
+		CURR_VAL=$($SSH_CMD curl -s $UNIT_CTRL$URI)
 		if [ "$(echo $CURR_VAL | jq -r type)" = "array" ]; then
-			SUFFIX=$(cat)
-			echo $CURR_VAL | jq ". |= [$SUFFIX] + ." | curl -X PUT --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+			echo $CURR_VAL | jq ". |= [$SUFFIX] + ." | $SSH_CMD curl -X PUT --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 		else
 			echo "${0##*/}: ERROR: INSERT method must be used with an array"
 			exit 3
 		fi
 	else
-		echo "$(cat)" | curl -X $METHOD --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
+		echo "$(cat)" | $SSH_CMD curl -X $METHOD --data-binary @- $UNIT_CTRL$URI 2> /tmp/${0##*/}.$$ | $PRETTY
 	fi
 fi
 


### PR DESCRIPTION
Inspired by @codecowboydotio , added remote configuration mode by detecting `http`-prefixed URIs.

Took advantage of existing use of bash variables for caching the control socket to provide this as an environment variable. This is extra-convenient for long-lived instances or lengthy config sessions, so that the host+port doesn't need to be repeated.
